### PR TITLE
Small change to add cross platform config path fix

### DIFF
--- a/src/StardewModdingAPI/Mod.cs
+++ b/src/StardewModdingAPI/Mod.cs
@@ -15,9 +15,9 @@ namespace StardewModdingAPI
         public string PathOnDisk { get; internal set; }
 
         /// <summary>
-        ///     A basic path to store your mod's config at.
+        ///     A cross platform basic path to store your mod's config at.
         /// </summary>
-        public string BaseConfigPath => PathOnDisk + "\\config.json";
+        public string BaseConfigPath => PathOnDisk + Path.DirectorySeparatorChar + "config.json";
 
         /// <summary>
         ///     A basic path to where per-save configs are stored


### PR DESCRIPTION
This is a small change to fix an issue I found with a mod (https://github.com/cantorsdust/TimeSpeed) when loading it's config.json. I tested the change on Linux and OSX, but not Windows although I feel it should be fine there too.
